### PR TITLE
fix: use correct folder for tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc && gapi build",
-    "lint": "tslint -c tslint.json 'development/**/*.{ts,tsx}'",
+    "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "pretest": "npm run lint",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "test": "jest --coverage"


### PR DESCRIPTION
# Description
Use correct folder for `tslint` when running it with `npm run lint`

## Type of change

- [x] Non Breaking change

# Checklist:

- [x] Fix `lint` script inside `package.json` so it will run correct folder `src` instead of `development`

