### PR TITLE
Replace only file extension, not across the filename

### DIFF
--- a/src/services/migrations-resolver/migrations-resolver.service.ts
+++ b/src/services/migrations-resolver/migrations-resolver.service.ts
@@ -90,6 +90,6 @@ export class MigrationsResolver {
   }
 
   replaceFilenameJsWithTs(fileName: string) {
-    return fileName.replace('ts', 'js');
+    return fileName.replace('.ts', '.js');
   }
 }


### PR DESCRIPTION
## Description
If you have ts anywhere else in the fileName, xmigrate will error out with following error:
```
🔥  Status: Operation executed with error
🧨  Error: {"fileName":"20230117171823-migrate_products.ts","migrated":[]}
📨  Message: Cannot find module '/migrations/.xmigrate/20230117171823-migrate_producjs.ts'
Require stack:
- /workspaces/obsidian/node_modules/@rxdi/xmigrate/dist/main.js
```